### PR TITLE
kernel: can: fix MCP251x CAN controller module autoload

### DIFF
--- a/package/kernel/linux/modules/can.mk
+++ b/package/kernel/linux/modules/can.mk
@@ -152,7 +152,7 @@ define KernelPackage/can-mcp251x
 	CONFIG_SPI=y \
 	CONFIG_CAN_MCP251X
   FILES:=$(LINUX_DIR)/drivers/net/can/spi/mcp251x.ko
-  AUTOLOAD:=$(call AutoProbe,can-mcp251x)
+  AUTOLOAD:=$(call AutoProbe,mcp251x)
   $(call AddDepends/can)
 endef
 


### PR DESCRIPTION
Fix autoload module name for can-mcp251x kmod.

Signed-off-by: Tim Harvey <tharvey@gateworks.com>
(cherry picked from commit 29d02d8ce584fa7e420204e04dde1e17e14e009c)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
